### PR TITLE
Support `caused at` on error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ bootstrap: installdeps
 		github.com/moznion/go-errgen/cmd/errgen
 
 errgen:
-	./author/errgen.sh
+	go generate ./...
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Please refer to the godoc: [![GoDoc](https://godoc.org/github.com/moznion/gowrtr
 
 Methods of this library act as immutable. It means it doesn't change any internal state implicitly, so you can take a snapshot of the code generator. That is useful to reuse and derive the code generator instance.
 
+### Debug friendly
+
+This library shows "where is a cause of the error" when code generator raises an error. This means each error message contains a pointer for the error source (i.e. file name and the line number).  This should be helpful for debugging.
+
+Error messages example:
+
+```
+[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at /tmp/main.go:22)
+```
+
 ### Supported syntax
 
 - [x] `package`

--- a/author/errgen.sh
+++ b/author/errgen.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-CURRENT_PATH="$(cd "$(dirname "$0")" || exit; pwd)"
-PATH="$CURRENT_PATH/bin:$PATH"
-
-(cd "$CURRENT_PATH/.." && go generate ./...)
-

--- a/generator/anonymous_func.go
+++ b/generator/anonymous_func.go
@@ -1,6 +1,8 @@
 package generator
 
-import "github.com/moznion/gowrtr/internal/errmsg"
+import (
+	"github.com/moznion/gowrtr/internal/errmsg"
+)
 
 // AnonymousFunc represents a code generator for anonymous func.
 type AnonymousFunc struct {
@@ -8,6 +10,7 @@ type AnonymousFunc struct {
 	anonymousFuncSignature *AnonymousFuncSignature
 	statements             []Statement
 	funcInvocation         *FuncInvocation
+	caller                 string
 }
 
 // NewAnonymousFunc returns a new `AnonymousFunc`.
@@ -17,6 +20,7 @@ func NewAnonymousFunc(goFunc bool, signature *AnonymousFuncSignature, statements
 		goFunc:                 goFunc,
 		anonymousFuncSignature: signature,
 		statements:             statements,
+		caller:                 fetchClientCallerLine(),
 	}
 }
 
@@ -28,6 +32,7 @@ func (ifg *AnonymousFunc) AddStatements(statements ...Statement) *AnonymousFunc 
 		anonymousFuncSignature: ifg.anonymousFuncSignature,
 		statements:             append(ifg.statements, statements...),
 		funcInvocation:         ifg.funcInvocation,
+		caller:                 ifg.caller,
 	}
 }
 
@@ -39,6 +44,7 @@ func (ifg *AnonymousFunc) Statements(statements ...Statement) *AnonymousFunc {
 		anonymousFuncSignature: ifg.anonymousFuncSignature,
 		statements:             statements,
 		funcInvocation:         ifg.funcInvocation,
+		caller:                 ifg.caller,
 	}
 }
 
@@ -50,6 +56,7 @@ func (ifg *AnonymousFunc) Invocation(funcInvocation *FuncInvocation) *AnonymousF
 		anonymousFuncSignature: ifg.anonymousFuncSignature,
 		statements:             ifg.statements,
 		funcInvocation:         funcInvocation,
+		caller:                 ifg.caller,
 	}
 }
 
@@ -64,7 +71,7 @@ func (ifg *AnonymousFunc) Generate(indentLevel int) (string, error) {
 	stmt += "func"
 
 	if ifg.anonymousFuncSignature == nil {
-		return "", errmsg.AnonymousFuncSignatureIsNilError()
+		return "", errmsg.AnonymousFuncSignatureIsNilError(ifg.caller)
 	}
 
 	sig, err := ifg.anonymousFuncSignature.Generate(0)

--- a/generator/anonymous_func_signature_test.go
+++ b/generator/anonymous_func_signature_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -41,7 +43,9 @@ func TestShouldGenerateAnonymousFuncSignatureRaisesErrorWhenParamNameIsEmpty(t *
 		NewFuncParameter("", "string"),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncParameterNameIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncParameterNameIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateAnonymousFuncSignatureRaisesErrorWhenParamTypeIsEmpty(t *testing.T) {
@@ -49,5 +53,7 @@ func TestShouldGenerateAnonymousFuncSignatureRaisesErrorWhenParamTypeIsEmpty(t *
 		NewFuncParameter("foo", ""),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.LastFuncParameterTypeIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.LastFuncParameterTypeIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/anonymous_func_test.go
+++ b/generator/anonymous_func_test.go
@@ -145,7 +145,9 @@ func TestShouldGenerateAnonymousFuncRaisesErrorWhenStatementRaisesError(t *testi
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateAnonymousFuncRaisesErrorWhenFuncInvocationRaisesError(t *testing.T) {

--- a/generator/anonymous_func_test.go
+++ b/generator/anonymous_func_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -117,7 +119,9 @@ func TestShouldGenerateAnonymousFuncRaisesErrorWhenAnonymousFuncSignatureIsNil(t
 		nil,
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.AnonymousFuncSignatureIsNilError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.AnonymousFuncSignatureIsNilError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateAnonymousFuncRaisesErrorWhenAnonymousFuncSignatureRaisesError(t *testing.T) {

--- a/generator/anonymous_func_test.go
+++ b/generator/anonymous_func_test.go
@@ -154,5 +154,7 @@ func TestShouldGenerateAnonymousFuncRaisesErrorWhenFuncInvocationRaisesError(t *
 		NewAnonymousFuncSignature(),
 	).Invocation(NewFuncInvocation(""))
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncInvocationParameterIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncInvocationParameterIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/anonymous_func_test.go
+++ b/generator/anonymous_func_test.go
@@ -132,7 +132,9 @@ func TestShouldGenerateAnonymousFuncRaisesErrorWhenAnonymousFuncSignatureRaisesE
 		),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncParameterNameIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncParameterNameIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateAnonymousFuncRaisesErrorWhenStatementRaisesError(t *testing.T) {

--- a/generator/case.go
+++ b/generator/case.go
@@ -11,6 +11,7 @@ import (
 type Case struct {
 	condition  string
 	statements []Statement
+	caller     string
 }
 
 // NewCase creates a new `Case`.
@@ -18,6 +19,7 @@ func NewCase(condition string, statements ...Statement) *Case {
 	return &Case{
 		condition:  condition,
 		statements: statements,
+		caller:     fetchClientCallerLine(),
 	}
 }
 
@@ -43,7 +45,7 @@ func (c *Case) Statements(statements ...Statement) *Case {
 func (c *Case) Generate(indentLevel int) (string, error) {
 	condition := c.condition
 	if condition == "" {
-		return "", errmsg.CaseConditionIsEmptyError()
+		return "", errmsg.CaseConditionIsEmptyError(c.caller)
 	}
 
 	indent := buildIndent(indentLevel)

--- a/generator/case_test.go
+++ b/generator/case_test.go
@@ -64,5 +64,7 @@ func TestShouldGenerateCaseRaisesErrorWhenStatementsRaisesError(t *testing.T) {
 		NewFunc(nil, NewFuncSignature("")),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/case_test.go
+++ b/generator/case_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -51,7 +53,9 @@ func TestShouldGenerateCase(t *testing.T) {
 func TestShouldGenerateCaseRaisesErrorWhenConditionIsEmpty(t *testing.T) {
 	generator := NewCase("")
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.CaseConditionIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.CaseConditionIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateCaseRaisesErrorWhenStatementsRaisesError(t *testing.T) {

--- a/generator/code_block_test.go
+++ b/generator/code_block_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -94,5 +96,7 @@ func TestShouldGenerateCodeBlockGiveUpWhenStatementRaisesError(t *testing.T) {
 		NewFunc(nil, NewFuncSignature("")),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/composite_literal_test.go
+++ b/generator/composite_literal_test.go
@@ -82,5 +82,7 @@ func TestShouldGenerateCompositeLiteralRaiseError(t *testing.T) {
 
 func TestShouldGenerateCompositeLiteralRaiseErrorWhenValueIsEmpty(t *testing.T) {
 	_, err := NewCompositeLiteral("[]string").AddField("foo", NewRawStatement("")).Generate(0)
-	assert.EqualError(t, err, errmsg.ValueOfCompositeLiteralIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.ValueOfCompositeLiteralIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/composite_literal_test.go
+++ b/generator/composite_literal_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -73,7 +75,9 @@ func TestShouldGenerateCompositeLiteralWithEmptyKey(t *testing.T) {
 
 func TestShouldGenerateCompositeLiteralRaiseError(t *testing.T) {
 	_, err := NewCompositeLiteral("").AddField("foo", NewIf("")).Generate(0)
-	assert.EqualError(t, err, errmsg.IfConditionIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.IfConditionIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateCompositeLiteralRaiseErrorWhenValueIsEmpty(t *testing.T) {

--- a/generator/default_case_test.go
+++ b/generator/default_case_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -52,5 +54,7 @@ func TestShouldGenerateDefaultCaseRaisesErrorWhenStatementsRaisesError(t *testin
 		NewFunc(nil, NewFuncSignature("")),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/else_if_test.go
+++ b/generator/else_if_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -70,5 +72,7 @@ func TestShouldGenerateElseIfRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/else_test.go
+++ b/generator/else_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -54,5 +56,7 @@ func TestShouldGenerateElseCodeRaisesError(t *testing.T) {
 		NewFunc(nil, NewFuncSignature("")),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/for_test.go
+++ b/generator/for_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -73,5 +75,7 @@ func TestShouldGenerateForCodeGiveUpWhenStatementRaisesError(t *testing.T) {
 		NewFunc(nil, NewFuncSignature("")),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/frame_fetcher.go
+++ b/generator/frame_fetcher.go
@@ -28,3 +28,17 @@ func fetchClientCallerLine(skip ...int) string {
 
 	return ""
 }
+
+func fetchClientCallerLineAsSlice(size int, skip ...int) []string {
+	s := 3
+	if len(skip) > 0 {
+		s = skip[0]
+	}
+
+	caller := fetchClientCallerLine(s)
+	callers := make([]string, size)
+	for i := 0; i < size; i++ {
+		callers[i] = caller
+	}
+	return callers
+}

--- a/generator/frame_fetcher.go
+++ b/generator/frame_fetcher.go
@@ -11,6 +11,8 @@ func fetchClientCallerLine(skip ...int) string {
 	if len(skip) > 0 {
 		s = skip[0]
 	}
+
+	caller := ""
 	for {
 		pc, file, line, ok := runtime.Caller(s)
 		f := runtime.FuncForPC(pc)
@@ -23,10 +25,11 @@ func fetchClientCallerLine(skip ...int) string {
 			break
 		}
 
-		return fmt.Sprintf("%s:%d", file, line)
+		caller = fmt.Sprintf("%s:%d", file, line)
+		break
 	}
 
-	return ""
+	return caller
 }
 
 func fetchClientCallerLineAsSlice(size int, skip ...int) []string {

--- a/generator/frame_fetcher.go
+++ b/generator/frame_fetcher.go
@@ -1,0 +1,30 @@
+package generator
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+func fetchClientCallerLine(skip ...int) string {
+	s := 2
+	if len(skip) > 0 {
+		s = skip[0]
+	}
+	for {
+		pc, file, line, ok := runtime.Caller(s)
+		f := runtime.FuncForPC(pc)
+		if strings.Contains(f.Name(), "github.com/moznion/gowrtr") {
+			s++
+			continue
+		}
+
+		if !ok {
+			break
+		}
+
+		return fmt.Sprintf("%s:%d", file, line)
+	}
+
+	return ""
+}

--- a/generator/frame_fetcher_test.go
+++ b/generator/frame_fetcher_test.go
@@ -1,0 +1,18 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchClientCallerLineShouldBeNG(t *testing.T) {
+	caller := fetchClientCallerLine(10000)
+	assert.Empty(t, caller)
+}
+
+func TestFetchCallerLineAsSliceShouldBeNG(t *testing.T) {
+	callers := fetchClientCallerLineAsSlice(1, 10000)
+	assert.Len(t, callers, 1)
+	assert.Empty(t, callers[0])
+}

--- a/generator/func.go
+++ b/generator/func.go
@@ -9,6 +9,7 @@ type Func struct {
 	funcReceiver  *FuncReceiver
 	funcSignature *FuncSignature
 	statements    []Statement
+	caller        string
 }
 
 // NewFunc returns a new `Func`.
@@ -17,6 +18,7 @@ func NewFunc(receiver *FuncReceiver, signature *FuncSignature, statements ...Sta
 		funcReceiver:  receiver,
 		funcSignature: signature,
 		statements:    statements,
+		caller:        fetchClientCallerLine(),
 	}
 }
 
@@ -59,7 +61,7 @@ func (fg *Func) Generate(indentLevel int) (string, error) {
 	}
 
 	if fg.funcSignature == nil {
-		return "", errmsg.FuncSignatureIsNilError()
+		return "", errmsg.FuncSignatureIsNilError(fg.caller)
 	}
 	sig, err := fg.funcSignature.Generate(0)
 	if err != nil {

--- a/generator/func_invocation.go
+++ b/generator/func_invocation.go
@@ -9,32 +9,40 @@ import (
 // FuncInvocation represents a code generator for func invocation.
 type FuncInvocation struct {
 	parameters []string
+	callers    []string
 }
 
 // NewFuncInvocation returns a new `FuncInvocation`.
 func NewFuncInvocation(parameters ...string) *FuncInvocation {
 	return &FuncInvocation{
 		parameters: parameters,
+		callers:    fetchClientCallerLineAsSlice(len(parameters)),
 	}
 }
 
 // AddParameters adds parameters of func invocation to `FuncInvocation`. This does *not* set, just add.
 // This method returns a *new* `FuncInvocation`; it means this method acts as immutable.
 func (fig *FuncInvocation) AddParameters(parameters ...string) *FuncInvocation {
-	return NewFuncInvocation(append(fig.parameters, parameters...)...)
+	return &FuncInvocation{
+		parameters: append(fig.parameters, parameters...),
+		callers:    append(fig.callers, fetchClientCallerLineAsSlice(len(parameters))...),
+	}
 }
 
 // Parameters sets parameters of func invocation to `FuncInvocation`. This does *not* add, just set.
 // This method returns a *new* `FuncInvocation`; it means this method acts as immutable.
 func (fig *FuncInvocation) Parameters(parameters ...string) *FuncInvocation {
-	return NewFuncInvocation(parameters...)
+	return &FuncInvocation{
+		parameters: parameters,
+		callers:    fetchClientCallerLineAsSlice(len(parameters)),
+	}
 }
 
 // Generate generates the func invocation as golang code.
 func (fig *FuncInvocation) Generate(indentLevel int) (string, error) {
-	for _, param := range fig.parameters {
+	for i, param := range fig.parameters {
 		if param == "" {
-			return "", errmsg.FuncInvocationParameterIsEmptyError()
+			return "", errmsg.FuncInvocationParameterIsEmptyError(fig.callers[i])
 		}
 	}
 

--- a/generator/func_invocation_test.go
+++ b/generator/func_invocation_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -34,5 +36,7 @@ func TestShouldGenerateFuncInvocationCode(t *testing.T) {
 func TestShouldGenerateFuncInvocationRaisesErrorWhenParameterIsEmpty(t *testing.T) {
 	generator := NewFuncInvocation("foo", "", "bar")
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncInvocationParameterIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncInvocationParameterIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/func_receiver.go
+++ b/generator/func_receiver.go
@@ -8,33 +8,35 @@ import (
 
 // FuncReceiver represents a code generator for the receiver of the func.
 type FuncReceiver struct {
-	Name string
-	Type string
+	name   string
+	typ    string
+	caller string
 }
 
 // NewFuncReceiver returns a new `FuncReceiver`.
 func NewFuncReceiver(name string, typ string) *FuncReceiver {
 	return &FuncReceiver{
-		Name: name,
-		Type: typ,
+		name:   name,
+		typ:    typ,
+		caller: fetchClientCallerLine(),
 	}
 }
 
 // Generate generates a receiver of the func as golang code.
 func (f *FuncReceiver) Generate(indentLevel int) (string, error) {
-	name := f.Name
-	typ := f.Type
+	name := f.name
+	typ := f.typ
 
 	if typ == "" && name == "" {
 		return "", nil
 	}
 
 	if name == "" {
-		return "", errmsg.FuncReceiverNameIsEmptyError()
+		return "", errmsg.FuncReceiverNameIsEmptyError(f.caller)
 	}
 
 	if typ == "" {
-		return "", errmsg.FuncReceiverTypeIsEmptyError()
+		return "", errmsg.FuncReceiverTypeIsEmptyError(f.caller)
 	}
 
 	return fmt.Sprintf("(%s %s)", name, typ), nil

--- a/generator/func_receiver_test.go
+++ b/generator/func_receiver_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -25,11 +27,15 @@ func TestShouldGeneratingFuncReceiverCodeBeSuccessfulWithEmpty(t *testing.T) {
 func TestShouldGeneratingFuncReceiverRaisesErrorWhenFuncReceiverNameIsEmpty(t *testing.T) {
 	funcReceiver := NewFuncReceiver("", "*Foo")
 	_, err := funcReceiver.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncReceiverNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncReceiverNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGeneratingFuncReceiverRaisesErrorWhenFuncReceiverTypeIsEmpty(t *testing.T) {
 	funcReceiver := NewFuncReceiver("f", "")
 	_, err := funcReceiver.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncReceiverTypeIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncReceiverTypeIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/func_signature_test.go
+++ b/generator/func_signature_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -78,7 +80,9 @@ func TestShouldRaiseErrorWhenFuncParameterNameIsEmpty(t *testing.T) {
 	)
 
 	_, err := sig.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncParameterNameIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncParameterNameIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldRaiseErrorWhenLastFuncParameterTypeIsEmpty(t *testing.T) {
@@ -89,7 +93,9 @@ func TestShouldRaiseErrorWhenLastFuncParameterTypeIsEmpty(t *testing.T) {
 	)
 
 	_, err := sig.Generate(0)
-	assert.EqualError(t, err, errmsg.LastFuncParameterTypeIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.LastFuncParameterTypeIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGeneratingFuncSignatureWithNamedReturnValue(t *testing.T) {

--- a/generator/func_signature_test.go
+++ b/generator/func_signature_test.go
@@ -69,7 +69,9 @@ func TestShouldRaiseErrorWhenFuncNameIsEmpty(t *testing.T) {
 	sig := NewFuncSignature("")
 
 	_, err := sig.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldRaiseErrorWhenFuncParameterNameIsEmpty(t *testing.T) {
@@ -176,5 +178,7 @@ func TestShouldGeneratingFuncSignatureRaisesUnnamedRetTypeIsAfterNamedRetType(t 
 		AddReturnTypeStructs(NewFuncReturnType("string", "foo")).
 		AddReturnTypeStructs(NewFuncReturnType("error", ""))
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.UnnamedReturnTypeAppearsAfterNamedReturnTypeError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.UnnamedReturnTypeAppearsAfterNamedReturnTypeError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/func_test.go
+++ b/generator/func_test.go
@@ -98,7 +98,9 @@ func TestShouldGenerateFuncCodeGiveUpWhenFuncReceiverRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncReceiverNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncReceiverNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateFuncCodeGiveUpWhenStatementRaisesError(t *testing.T) {

--- a/generator/func_test.go
+++ b/generator/func_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -80,7 +82,9 @@ func TestShouldGenerateFuncCodeGiveUpWhenFuncSignatureIsNil(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncSignatureIsNilError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncSignatureIsNilError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateFuncCodeGiveUpWhenFuncReceiverRaisesError(t *testing.T) {

--- a/generator/func_test.go
+++ b/generator/func_test.go
@@ -72,7 +72,9 @@ func TestShouldGenerateFuncCodeGiveUpWhenFuncNameIsEmpty(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateFuncCodeGiveUpWhenFuncSignatureIsNil(t *testing.T) {
@@ -116,5 +118,7 @@ func TestShouldGenerateFuncCodeGiveUpWhenStatementRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/if.go
+++ b/generator/if.go
@@ -12,6 +12,7 @@ type If struct {
 	statements   []Statement
 	elseIfBlocks []*ElseIf
 	elseBlock    *Else
+	caller       string
 }
 
 // NewIf returns a new `If`.
@@ -19,6 +20,7 @@ func NewIf(condition string, statements ...Statement) *If {
 	return &If{
 		condition:  condition,
 		statements: statements,
+		caller:     fetchClientCallerLine(),
 	}
 }
 
@@ -30,6 +32,7 @@ func (ig *If) AddStatements(statements ...Statement) *If {
 		statements:   append(ig.statements, statements...),
 		elseIfBlocks: ig.elseIfBlocks,
 		elseBlock:    ig.elseBlock,
+		caller:       ig.caller,
 	}
 }
 
@@ -41,6 +44,7 @@ func (ig *If) Statements(statements ...Statement) *If {
 		statements:   statements,
 		elseIfBlocks: ig.elseIfBlocks,
 		elseBlock:    ig.elseBlock,
+		caller:       ig.caller,
 	}
 }
 
@@ -52,6 +56,7 @@ func (ig *If) AddElseIf(blocks ...*ElseIf) *If {
 		statements:   ig.statements,
 		elseIfBlocks: append(ig.elseIfBlocks, blocks...),
 		elseBlock:    ig.elseBlock,
+		caller:       ig.caller,
 	}
 }
 
@@ -63,6 +68,7 @@ func (ig *If) ElseIf(blocks ...*ElseIf) *If {
 		statements:   ig.statements,
 		elseIfBlocks: blocks,
 		elseBlock:    ig.elseBlock,
+		caller:       ig.caller,
 	}
 }
 
@@ -74,6 +80,7 @@ func (ig *If) Else(block *Else) *If {
 		statements:   ig.statements,
 		elseIfBlocks: ig.elseIfBlocks,
 		elseBlock:    block,
+		caller:       ig.caller,
 	}
 }
 
@@ -82,7 +89,7 @@ func (ig *If) Generate(indentLevel int) (string, error) {
 	indent := buildIndent(indentLevel)
 
 	if ig.condition == "" {
-		return "", errmsg.IfConditionIsEmptyError()
+		return "", errmsg.IfConditionIsEmptyError(ig.caller)
 	}
 
 	stmt := fmt.Sprintf("%sif %s {\n", indent, ig.condition)

--- a/generator/if_test.go
+++ b/generator/if_test.go
@@ -146,7 +146,9 @@ func TestShouldGenerateIfAndElseIfAndElseCode(t *testing.T) {
 
 func TestShouldGenerateIfRaisesError(t *testing.T) {
 	_, err := NewIf("").Generate(0)
-	assert.EqualError(t, err, errmsg.IfConditionIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.IfConditionIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateIfElseIfRaisesError(t *testing.T) {

--- a/generator/if_test.go
+++ b/generator/if_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -74,7 +76,9 @@ func TestShouldGenerateIfCodeGiveUpWhenStatementRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateIfAndElseIfAndElseCode(t *testing.T) {
@@ -153,7 +157,9 @@ func TestShouldGenerateIfElseIfRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateIfElseRaisesError(t *testing.T) {
@@ -164,5 +170,7 @@ func TestShouldGenerateIfElseRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/interface.go
+++ b/generator/interface.go
@@ -10,6 +10,7 @@ import (
 type Interface struct {
 	name           string
 	funcSignatures []*FuncSignature
+	caller         string
 }
 
 // NewInterface returns a new `Interface`.
@@ -17,6 +18,7 @@ func NewInterface(name string, funcSignatures ...*FuncSignature) *Interface {
 	return &Interface{
 		name:           name,
 		funcSignatures: funcSignatures,
+		caller:         fetchClientCallerLine(),
 	}
 }
 
@@ -26,6 +28,7 @@ func (ig *Interface) AddSignatures(sig ...*FuncSignature) *Interface {
 	return &Interface{
 		name:           ig.name,
 		funcSignatures: append(ig.funcSignatures, sig...),
+		caller:         ig.caller,
 	}
 }
 
@@ -35,13 +38,14 @@ func (ig *Interface) Signatures(sig ...*FuncSignature) *Interface {
 	return &Interface{
 		name:           ig.name,
 		funcSignatures: sig,
+		caller:         ig.caller,
 	}
 }
 
 // Generate generates `interface` block as golang code.
 func (ig *Interface) Generate(indentLevel int) (string, error) {
 	if ig.name == "" {
-		return "", errmsg.InterfaceNameIsEmptyError()
+		return "", errmsg.InterfaceNameIsEmptyError(ig.caller)
 	}
 
 	indent := buildIndent(indentLevel)

--- a/generator/interface_test.go
+++ b/generator/interface_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -117,5 +119,7 @@ func TestShouldRaiseErrorWhenFuncSignatureRaisesError(t *testing.T) {
 		NewFuncSignature(""),
 	)
 	_, err := in.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/interface_test.go
+++ b/generator/interface_test.go
@@ -110,7 +110,9 @@ func TestShouldGeneratingInterfaceCodeWithIndentBeSuccessful(t *testing.T) {
 func TestShouldRaiseErrorWhenInterfaceNameIsEmpty(t *testing.T) {
 	in := NewInterface("")
 	_, err := in.Generate(0)
-	assert.EqualError(t, err, errmsg.InterfaceNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.InterfaceNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldRaiseErrorWhenFuncSignatureRaisesError(t *testing.T) {

--- a/generator/root_test.go
+++ b/generator/root_test.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -478,7 +479,9 @@ func TestShouldGenerateCodeRaisesError(t *testing.T) {
 	)
 
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncSignatureIsNilError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncSignatureIsNilError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateCodeRaiseErrorWhenCodeFormatterIsExited(t *testing.T) {

--- a/generator/struct_test.go
+++ b/generator/struct_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -43,17 +45,23 @@ func TestShouldRaiseErrorWhenStructNameIsEmpty(t *testing.T) {
 	structGenerator := NewStruct("")
 
 	_, err := structGenerator.Generate(0)
-	assert.EqualError(t, err, errmsg.StructNameIsNilErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.StructNameIsNilErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldRaiseErrorWhenFieldNameIsEmpty(t *testing.T) {
 	structGenerator := NewStruct("TestStruct").AddField("", "string")
 	_, err := structGenerator.Generate(0)
-	assert.EqualError(t, err, errmsg.StructFieldNameIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.StructFieldNameIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldRaiseErrorWhenFieldTypeIsEmpty(t *testing.T) {
 	structGenerator := NewStruct("TestStruct").AddField("Foo", "")
 	_, err := structGenerator.Generate(0)
-	assert.EqualError(t, err, errmsg.StructFieldTypeIsEmptyErr().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.StructFieldTypeIsEmptyErr("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/switch_test.go
+++ b/generator/switch_test.go
@@ -91,5 +91,7 @@ func TestShouldGenerateSwitchRaisesErrorWhenDefaultRaisesError(t *testing.T) {
 		),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.FuncNameIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.FuncNameIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }

--- a/generator/switch_test.go
+++ b/generator/switch_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -77,7 +79,9 @@ func TestShouldGenerateSwitchRaisesErrorWhenCaseRaisesError(t *testing.T) {
 		NewCase(""),
 	)
 	_, err := generator.Generate(0)
-	assert.EqualError(t, err, errmsg.CaseConditionIsEmptyError().Error())
+	assert.Regexp(t, regexp.MustCompile(
+		`^\`+strings.Split(errmsg.CaseConditionIsEmptyError("").Error(), " ")[0],
+	), err.Error())
 }
 
 func TestShouldGenerateSwitchRaisesErrorWhenDefaultRaisesError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/moznion/gowrtr
 
 require (
-	github.com/moznion/go-errgen v1.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/moznion/go-errgen v1.3.2
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
-	golang.org/x/tools v0.0.0-20190111214448-fc1d57b08d7b // indirect
+	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1
+	golang.org/x/tools v0.0.0-20190121143147-24cd39ecf745 // indirect
 )

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -16,7 +16,7 @@ type errs struct {
 	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil (caused at %s)" vars:"caller string"`
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
-	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty"`
+	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type (caused at %s)" vars:"caller string"`
 	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty"`
 }

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -15,7 +15,7 @@ type errs struct {
 	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil"`
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`
-	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty"`
+	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty"`
 	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type"`
 	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -2,9 +2,9 @@ package errmsg
 
 //go:generate errgen -type=errs -prefix=GOWRTR-
 type errs struct {
-	StructNameIsNilErr                                error `errmsg:"struct name must not be empty, but it gets empty"`
-	StructFieldNameIsEmptyErr                         error `errmsg:"field name must not be empty, but it gets empty"`
-	StructFieldTypeIsEmptyErr                         error `errmsg:"field type must not be empty, but it gets empty"`
+	StructNameIsNilErr                                error `errmsg:"struct name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
+	StructFieldNameIsEmptyErr                         error `errmsg:"field name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
+	StructFieldTypeIsEmptyErr                         error `errmsg:"field type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncParameterNameIsEmptyErr                       error `errmsg:"func parameter name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty (caused at %s)" vars:"caller string"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -9,8 +9,8 @@ type errs struct {
 	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty"`
 	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty"`
-	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty"`
-	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty"`
+	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
+	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil (caused at %s)" vars:"caller string"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -11,7 +11,7 @@ type errs struct {
 	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty"`
 	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty"`
 	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty"`
-	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil"`
+	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil"`
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -12,7 +12,7 @@ type errs struct {
 	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty"`
 	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty"`
 	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil"`
-	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil"`
+	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil"`
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -13,7 +13,7 @@ type errs struct {
 	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty"`
 	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
 	AnonymousFuncSignatureIsNilError                  error `errmsg:"anonymous func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`
-	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil"`
+	FuncInvocationParameterIsEmptyError               error `errmsg:"a parameter of function invocation must not be nil, but it gets nil (caused at %s)" vars:"caller string"`
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -5,8 +5,8 @@ type errs struct {
 	StructNameIsNilErr                                error `errmsg:"struct name must not be empty, but it gets empty"`
 	StructFieldNameIsEmptyErr                         error `errmsg:"field name must not be empty, but it gets empty"`
 	StructFieldTypeIsEmptyErr                         error `errmsg:"field type must not be empty, but it gets empty"`
-	FuncParameterNameIsEmptyErr                       error `errmsg:"func parameter name must not be empty, but it gets empty"`
-	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty"`
+	FuncParameterNameIsEmptyErr                       error `errmsg:"func parameter name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
+	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty"`
 	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty"`
 	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -18,5 +18,5 @@ type errs struct {
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type (caused at %s)" vars:"caller string"`
-	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty"`
+	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 }

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -8,7 +8,7 @@ type errs struct {
 	FuncParameterNameIsEmptyErr                       error `errmsg:"func parameter name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
-	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty"`
+	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncSignatureIsNilError                           error `errmsg:"func signature must not be nil, bit it gets nil (caused at %s)" vars:"caller string"`

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -7,7 +7,7 @@ type errs struct {
 	StructFieldTypeIsEmptyErr                         error `errmsg:"field type must not be empty, but it gets empty"`
 	FuncParameterNameIsEmptyErr                       error `errmsg:"func parameter name must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	LastFuncParameterTypeIsEmptyErr                   error `errmsg:"the last func parameter type must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
-	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty"`
+	FuncNameIsEmptyError                              error `errmsg:"name of func must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	InterfaceNameIsEmptyError                         error `errmsg:"name of interface must not be empty, but it gets empty"`
 	FuncReceiverNameIsEmptyError                      error `errmsg:"name of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	FuncReceiverTypeIsEmptyError                      error `errmsg:"type of func receiver must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
@@ -17,6 +17,6 @@ type errs struct {
 	CodeFormatterError                                error `errmsg:"code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"" vars:"cmd string, msg string, err error"`
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty (caused at %s)" vars:"caller string"`
 	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty"`
-	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type"`
+	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type (caused at %s)" vars:"caller string"`
 	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty"`
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -24,13 +24,13 @@ func StructFieldTypeIsEmptyErr() error {
 }
 
 // FuncParameterNameIsEmptyErr returns the error.
-func FuncParameterNameIsEmptyErr() error {
-	return errors.New(`[GOWRTR-4] func parameter name must not be empty, but it gets empty`)
+func FuncParameterNameIsEmptyErr(caller string) error {
+	return fmt.Errorf(`[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // LastFuncParameterTypeIsEmptyErr returns the error.
-func LastFuncParameterTypeIsEmptyErr() error {
-	return errors.New(`[GOWRTR-5] the last func parameter type must not be empty, but it gets empty`)
+func LastFuncParameterTypeIsEmptyErr(caller string) error {
+	return fmt.Errorf(`[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // FuncNameIsEmptyError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -39,8 +39,8 @@ func FuncNameIsEmptyError(caller string) error {
 }
 
 // InterfaceNameIsEmptyError returns the error.
-func InterfaceNameIsEmptyError() error {
-	return errors.New(`[GOWRTR-7] name of interface must not be empty, but it gets empty`)
+func InterfaceNameIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // FuncReceiverNameIsEmptyError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -74,8 +74,8 @@ func CodeFormatterError(cmd string, msg string, err error) error {
 }
 
 // CaseConditionIsEmptyError returns the error.
-func CaseConditionIsEmptyError() error {
-	return errors.New(`[GOWRTR-14] condition of case must not be empty, but it gets empty`)
+func CaseConditionIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // IfConditionIsEmptyError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -9,18 +9,18 @@ import (
 )
 
 // StructNameIsNilErr returns the error.
-func StructNameIsNilErr() error {
-	return errors.New(`[GOWRTR-1] struct name must not be empty, but it gets empty`)
+func StructNameIsNilErr(caller string) error {
+	return fmt.Errorf(`[GOWRTR-1] struct name must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // StructFieldNameIsEmptyErr returns the error.
-func StructFieldNameIsEmptyErr() error {
-	return errors.New(`[GOWRTR-2] field name must not be empty, but it gets empty`)
+func StructFieldNameIsEmptyErr(caller string) error {
+	return fmt.Errorf(`[GOWRTR-2] field name must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // StructFieldTypeIsEmptyErr returns the error.
-func StructFieldTypeIsEmptyErr() error {
-	return errors.New(`[GOWRTR-3] field type must not be empty, but it gets empty`)
+func StructFieldTypeIsEmptyErr(caller string) error {
+	return fmt.Errorf(`[GOWRTR-3] field type must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // FuncParameterNameIsEmptyErr returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-2] field name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-3] field type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -59,8 +59,8 @@ func FuncSignatureIsNilError() error {
 }
 
 // AnonymousFuncSignatureIsNilError returns the error.
-func AnonymousFuncSignatureIsNilError() error {
-	return errors.New(`[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil`)
+func AnonymousFuncSignatureIsNilError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)`, caller)
 }
 
 // FuncInvocationParameterIsEmptyError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -3,10 +3,7 @@
 
 package errmsg
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
 // StructNameIsNilErr returns the error.
 func StructNameIsNilErr(caller string) error {
@@ -89,11 +86,11 @@ func UnnamedReturnTypeAppearsAfterNamedReturnTypeError(caller string) error {
 }
 
 // ValueOfCompositeLiteralIsEmptyError returns the error.
-func ValueOfCompositeLiteralIsEmptyError() error {
-	return errors.New(`[GOWRTR-17] a value of composite literal must not be empty, but it gets empty`)
+func ValueOfCompositeLiteralIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-17] a value of composite literal must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-2] field name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-3] field type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-2] field name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-3] field type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty (caused at %s)", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty (caused at %s)"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -64,8 +64,8 @@ func AnonymousFuncSignatureIsNilError(caller string) error {
 }
 
 // FuncInvocationParameterIsEmptyError returns the error.
-func FuncInvocationParameterIsEmptyError() error {
-	return errors.New(`[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil`)
+func FuncInvocationParameterIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)`, caller)
 }
 
 // CodeFormatterError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -44,13 +44,13 @@ func InterfaceNameIsEmptyError() error {
 }
 
 // FuncReceiverNameIsEmptyError returns the error.
-func FuncReceiverNameIsEmptyError() error {
-	return errors.New(`[GOWRTR-8] name of func receiver must not be empty, but it gets empty`)
+func FuncReceiverNameIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // FuncReceiverTypeIsEmptyError returns the error.
-func FuncReceiverTypeIsEmptyError() error {
-	return errors.New(`[GOWRTR-9] type of func receiver must not be empty, but it gets empty`)
+func FuncReceiverTypeIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // FuncSignatureIsNilError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -79,8 +79,8 @@ func CaseConditionIsEmptyError(caller string) error {
 }
 
 // IfConditionIsEmptyError returns the error.
-func IfConditionIsEmptyError() error {
-	return errors.New(`[GOWRTR-15] condition of if must not be empty, but it gets empty`)
+func IfConditionIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // UnnamedReturnTypeAppearsAfterNamedReturnTypeError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty (caused at %s)", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -34,8 +34,8 @@ func LastFuncParameterTypeIsEmptyErr(caller string) error {
 }
 
 // FuncNameIsEmptyError returns the error.
-func FuncNameIsEmptyError() error {
-	return errors.New(`[GOWRTR-6] name of func must not be empty, but it gets empty`)
+func FuncNameIsEmptyError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)`, caller)
 }
 
 // InterfaceNameIsEmptyError returns the error.
@@ -84,8 +84,8 @@ func IfConditionIsEmptyError() error {
 }
 
 // UnnamedReturnTypeAppearsAfterNamedReturnTypeError returns the error.
-func UnnamedReturnTypeAppearsAfterNamedReturnTypeError() error {
-	return errors.New(`[GOWRTR-16] unnamed return type appears after named return type`)
+func UnnamedReturnTypeAppearsAfterNamedReturnTypeError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-16] unnamed return type appears after named return type (caused at %s)`, caller)
 }
 
 // ValueOfCompositeLiteralIsEmptyError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty (caused at %s)", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty (caused at %s)", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil (caused at %s)", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type (caused at %s)", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -54,8 +54,8 @@ func FuncReceiverTypeIsEmptyError() error {
 }
 
 // FuncSignatureIsNilError returns the error.
-func FuncSignatureIsNilError() error {
-	return errors.New(`[GOWRTR-10] func signature must not be nil, bit it gets nil`)
+func FuncSignatureIsNilError(caller string) error {
+	return fmt.Errorf(`[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)`, caller)
 }
 
 // AnonymousFuncSignatureIsNilError returns the error.
@@ -95,5 +95,5 @@ func ValueOfCompositeLiteralIsEmptyError() error {
 
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty (caused at %s)", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty (caused at %s)", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil (caused at %s)", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at %s)", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }

--- a/internal/vendor.go
+++ b/internal/vendor.go
@@ -1,0 +1,8 @@
+package internal
+
+import (
+	// For vendoring
+	_ "github.com/moznion/go-errgen"
+	// For vendoring
+	_ "golang.org/x/lint"
+)


### PR DESCRIPTION
This change expands error messages to show "where is the error from".

Error message example: `[GOWRTR-14] condition of case must not be empty, but it gets empty (caused at /tmp/main.go:22)`