### PR TITLE
Support empty keys on composite literal

### DIFF
--- a/generator/composite_literal.go
+++ b/generator/composite_literal.go
@@ -3,6 +3,8 @@ package generator
 import (
 	"fmt"
 	"strings"
+
+	"github.com/moznion/gowrtr/internal/errmsg"
 )
 
 type compositeLiteralField struct {
@@ -74,7 +76,15 @@ func (c *CompositeLiteral) Generate(indentLevel int) (string, error) {
 
 		genValue = strings.TrimSpace(genValue)
 
-		stmt += fmt.Sprintf("%s%s: %s,\n", nextLevelIndent, field.key, genValue)
+		stmt += nextLevelIndent
+
+		if key := field.key; key != "" {
+			stmt += key + ": "
+		}
+		if genValue == "" {
+			return "", errmsg.ValueOfCompositeLiteralIsEmptyError()
+		}
+		stmt += fmt.Sprintf("%s,\n", genValue)
 	}
 	stmt += fmt.Sprintf("%s}\n", indent)
 

--- a/generator/composite_literal_test.go
+++ b/generator/composite_literal_test.go
@@ -55,7 +55,28 @@ func TestShouldGenerateCompositeLiteralBeSuccess(t *testing.T) {
 	}
 }
 
+func TestShouldGenerateCompositeLiteralWithEmptyKey(t *testing.T) {
+	composeGenerator := NewCompositeLiteral("[]string").
+		AddFieldStr("", "foo").
+		AddFieldStr("", "bar").
+		AddFieldStr("", "buz")
+	gen, err := composeGenerator.Generate(0)
+	expected := `[]string{
+	"foo",
+	"bar",
+	"buz",
+}
+`
+	assert.NoError(t, err)
+	assert.Equal(t, expected, gen)
+}
+
 func TestShouldGenerateCompositeLiteralRaiseError(t *testing.T) {
 	_, err := NewCompositeLiteral("").AddField("foo", NewIf("")).Generate(0)
 	assert.EqualError(t, err, errmsg.IfConditionIsEmptyError().Error())
+}
+
+func TestShouldGenerateCompositeLiteralRaiseErrorWhenValueIsEmpty(t *testing.T) {
+	_, err := NewCompositeLiteral("[]string").AddField("foo", NewRawStatement("")).Generate(0)
+	assert.EqualError(t, err, errmsg.ValueOfCompositeLiteralIsEmptyError().Error())
 }

--- a/internal/errmsg/errmsg.go
+++ b/internal/errmsg/errmsg.go
@@ -18,4 +18,5 @@ type errs struct {
 	CaseConditionIsEmptyError                         error `errmsg:"condition of case must not be empty, but it gets empty"`
 	IfConditionIsEmptyError                           error `errmsg:"condition of if must not be empty, but it gets empty"`
 	UnnamedReturnTypeAppearsAfterNamedReturnTypeError error `errmsg:"unnamed return type appears after named return type"`
+	ValueOfCompositeLiteralIsEmptyError               error `errmsg:"a value of composite literal must not be empty, but it gets empty"`
 }

--- a/internal/errmsg/errs_errmsg_gen.go
+++ b/internal/errmsg/errs_errmsg_gen.go
@@ -3,8 +3,10 @@
 
 package errmsg
 
-import "errors"
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // StructNameIsNilErr returns the error.
 func StructNameIsNilErr() error {
@@ -86,24 +88,12 @@ func UnnamedReturnTypeAppearsAfterNamedReturnTypeError() error {
 	return errors.New(`[GOWRTR-16] unnamed return type appears after named return type`)
 }
 
+// ValueOfCompositeLiteralIsEmptyError returns the error.
+func ValueOfCompositeLiteralIsEmptyError() error {
+	return errors.New(`[GOWRTR-17] a value of composite literal must not be empty, but it gets empty`)
+}
+
 // ErrsList returns the list of errors.
 func ErrsList() []string {
-	return []string{
-		`[GOWRTR-1] struct name must not be empty, but it gets empty`,
-		`[GOWRTR-2] field name must not be empty, but it gets empty`,
-		`[GOWRTR-3] field type must not be empty, but it gets empty`,
-		`[GOWRTR-4] func parameter name must not be empty, but it gets empty`,
-		`[GOWRTR-5] the last func parameter type must not be empty, but it gets empty`,
-		`[GOWRTR-6] name of func must not be empty, but it gets empty`,
-		`[GOWRTR-7] name of interface must not be empty, but it gets empty`,
-		`[GOWRTR-8] name of func receiver must not be empty, but it gets empty`,
-		`[GOWRTR-9] type of func receiver must not be empty, but it gets empty`,
-		`[GOWRTR-10] func signature must not be nil, bit it gets nil`,
-		`[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil`,
-		`[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil`,
-		`[GOWRTR-13] code formatter raises error: command="%s", err="%s", msg="%s"`,
-		`[GOWRTR-14] condition of case must not be empty, but it gets empty`,
-		`[GOWRTR-15] condition of if must not be empty, but it gets empty`,
-		`[GOWRTR-16] unnamed return type appears after named return type`,
-	}
+	return []string{"[GOWRTR-1] struct name must not be empty, but it gets empty", "[GOWRTR-2] field name must not be empty, but it gets empty", "[GOWRTR-3] field type must not be empty, but it gets empty", "[GOWRTR-4] func parameter name must not be empty, but it gets empty", "[GOWRTR-5] the last func parameter type must not be empty, but it gets empty", "[GOWRTR-6] name of func must not be empty, but it gets empty", "[GOWRTR-7] name of interface must not be empty, but it gets empty", "[GOWRTR-8] name of func receiver must not be empty, but it gets empty", "[GOWRTR-9] type of func receiver must not be empty, but it gets empty", "[GOWRTR-10] func signature must not be nil, bit it gets nil", "[GOWRTR-11] anonymous func signature must not be nil, bit it gets nil", "[GOWRTR-12] a parameter of function invocation must not be nil, but it gets nil", "[GOWRTR-13] code formatter raises error: command=\"%s\", err=\"%s\", msg=\"%s\"", "[GOWRTR-14] condition of case must not be empty, but it gets empty", "[GOWRTR-15] condition of if must not be empty, but it gets empty", "[GOWRTR-16] unnamed return type appears after named return type", "[GOWRTR-17] a value of composite literal must not be empty, but it gets empty"}
 }


### PR DESCRIPTION
Previously it is impossible to create value by composite literal generator without any key. This pull-request supports such a way.

example:

```go
composeGenerator := generator.NewCompositeLiteral("[]string").
	AddFieldStr("", "foo").
	AddFieldStr("", "bar").
	AddFieldStr("", "buz")
```

then it generates:

```go
[]string{
	"foo",
	"bar",
	"buz",
}
```