### PR TITLE
fix func names to fix build of gonstructor

### DIFF
--- a/generator/func_signature.go
+++ b/generator/func_signature.go
@@ -71,9 +71,9 @@ func NewFuncSignature(funcName string) *FuncSignature {
 	}
 }
 
-// AddParameters adds parameters of the func to `FuncSignature`. This does *not* set, just add.
+// AddFuncParameters adds parameters of the func to `FuncSignature`. This does *not* set, just add.
 // This method returns a *new* `FuncSignature`; it means this method acts as immutable.
-func (f *FuncSignature) AddParameters(funcParameters ...*FuncParameter) *FuncSignature {
+func (f *FuncSignature) AddFuncParameters(funcParameters ...*FuncParameter) *FuncSignature {
 	return &FuncSignature{
 		funcName:           f.funcName,
 		funcParameters:     append(f.funcParameters, funcParameters...),
@@ -84,9 +84,9 @@ func (f *FuncSignature) AddParameters(funcParameters ...*FuncParameter) *FuncSig
 	}
 }
 
-// Parameters sets parameters of the func to `FuncSignature`. This does *not* add, just set.
+// FuncParameters sets parameters of the func to `FuncSignature`. This does *not* add, just set.
 // This method returns a *new* `FuncSignature`; it means this method acts as immutable.
-func (f *FuncSignature) Parameters(funcParameters ...*FuncParameter) *FuncSignature {
+func (f *FuncSignature) FuncParameters(funcParameters ...*FuncParameter) *FuncSignature {
 	return &FuncSignature{
 		funcName:           f.funcName,
 		funcParameters:     funcParameters,

--- a/generator/root.go
+++ b/generator/root.go
@@ -49,9 +49,9 @@ func (g *Root) Statements(statements ...Statement) *Root {
 	}
 }
 
-// Gofmt enables `gofmt`. If `gofmt` is enabled, it applies `gofmt` on code generation phase.
+// EnableGofmt enables `gofmt`. If `gofmt` is enabled, it applies `gofmt` on code generation phase.
 // This method returns a *new* `Root`; it means this method acts as immutable.
-func (g *Root) Gofmt(gofmtOptions ...string) *Root {
+func (g *Root) EnableGofmt(gofmtOptions ...string) *Root {
 	return &Root{
 		statements:     g.statements,
 		gofmt:          true,
@@ -61,9 +61,9 @@ func (g *Root) Gofmt(gofmtOptions ...string) *Root {
 	}
 }
 
-// Goimports enables `goimports`. If `goimports` is enabled, it applies `goimports` on code generation phase.
+// EnableGoimports enables `goimports`. If `goimports` is enabled, it applies `goimports` on code generation phase.
 // This method returns a *new* `Root`; it means this method acts as immutable.
-func (g *Root) Goimports() *Root {
+func (g *Root) EnableGoimports() *Root {
 	return &Root{
 		statements:     g.statements,
 		gofmt:          g.gofmt,
@@ -151,7 +151,6 @@ func applyCodeFormatter(generatedCode string, formatterCmdName string, formatter
 	echoCmd.Wait()
 	w.Close()
 	err := formatterCmd.Wait()
-
 	if err != nil {
 		cmds := []string{formatterCmdName}
 		return "", errmsg.CodeFormatterError(strings.Join(append(cmds, formatterOpts...), " "), errout.String(), err)


### PR DESCRIPTION
Currently gonstructor has compilation errors:
```
# github.com/moznion/gonstructor/internal/constructor
../../internal/constructor/all_args_constructor_generator.go:26:32: funcSignature.AddFuncParameters undefined (type *generator.FuncSignature has no field or method AddFuncParameters)
../../internal/constructor/builder_constructor_generator.go:44:56: generator.NewFuncSignature(strcase.ToCamel(field.FieldName)).AddFuncParameters undefined (type *generator.FuncSignature has no field or method AddFuncParameters)
```

and after fixing it you could get
```
# github.com/moznion/gonstructor/cmd/gonstructor
cmd/gonstructor/gonstructor.go:102:23: rootStmt.EnableGoimports undefined (type *generator.Root has no field or method EnableGoimports)
```