### PR TITLE
Generics support on various code points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gowrtr [![CircleCI](https://circleci.com/gh/moznion/gowrtr.svg?style=svg)](https://circleci.com/gh/moznion/gowrtr) [![codecov](https://codecov.io/gh/moznion/gowrtr/branch/master/graph/badge.svg)](https://codecov.io/gh/moznion/gowrtr) [![GoDoc](https://godoc.org/github.com/moznion/gowrtr/generator?status.svg)](https://godoc.org/github.com/moznion/gowrtr/generator) [![Go Report Card](https://goreportcard.com/badge/github.com/moznion/gowrtr)](https://goreportcard.com/report/github.com/moznion/gowrtr)
 ==
 
-gowrtr (pronunciation:`go writer`) is a library that supports golang code generation.
+gowrtr (pronunciation:`go writer`) is a library that supports golang code generation. This library is [go generics](https://go.dev/doc/tutorial/generics) ready!
 
 This library is inspired by [square/javapoet](https://github.com/square/javapoet).
 
@@ -32,8 +32,8 @@ func main() {
 			generator.NewRawStatement(`fmt.Println("hello, world!")`),
 		),
 	).
-		Gofmt("-s").
-		Goimports()
+	Gofmt("-s").
+	Goimports()
 
 	generated, err := generator.Generate(0)
 	if err != nil {
@@ -53,6 +53,72 @@ import "fmt"
 
 func main() {
         fmt.Println("hello, world!")
+}
+```
+
+Generics example is here:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/moznion/gowrtr/generator"
+)
+
+func main() {
+	generated, err := generator.NewRoot(
+		generator.NewComment(" THIS CODE WAS AUTO GENERATED"),
+		generator.NewPackage("main"),
+		generator.NewNewline(),
+		generator.NewStruct("MyStruct").
+			TypeParameters(TypeParameters{
+				generator.NewTypeParameter("T", "any"),
+			}).AddField("anything", "T"),
+		generator.NewNewline(),
+		generator.NewFunc(
+			nil,
+			generator.NewFuncSignature("foo").
+				TypeParameters(TypeParameters{
+					generator.NewTypeParameter("U", "any"),
+				}).
+				ReturnTypeStatements(generator.NewFuncReturnTypeWithTypeParam("MyStruct", []string{"U"})),
+		).AddStatements(generator.NewComment("do something")),
+		generator.NewNewline(),
+		generator.NewFunc(
+			generator.NewFuncReceiver("s", "MyStruct", "T"),
+			generator.NewFuncSignature("bar").
+				ReturnTypeStatements(generator.NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T"})),
+		).AddStatements(generator.NewComment("do something")),
+	).
+	Gofmt("-s").
+	Goimports().
+	Generate(0)
+
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(generated)
+}
+```
+
+then it generates the following golang code:
+
+```go
+// THIS CODE WAS AUTO GENERATED
+package main
+
+type MyStruct[T any] struct {
+	anything T
+}
+
+func foo[U any]() MyStruct[U] {
+	//do something
+}
+
+func (s MyStruct[T]) bar() MyStruct[T] {
+	//do something
 }
 ```
 
@@ -89,7 +155,9 @@ Error messages example:
 - [x] `package`
 - [x] `import`
 - [x] `struct`
+  - [x] generics type parameters
 - [x] `interface`
+  - [x] generics type parameters
 - [x] [composite literal](https://golang.org/doc/effective_go.html#composite_literals)
 - [x] `if`
   - [x] `else if`
@@ -100,6 +168,10 @@ Error messages example:
 - [x] `for`
 - [x] code block
 - [x] `func`
+  - [x] generics type parameters on the signature
+  - [x] generics type names on the receiver
+  - [x] generics type names on the return types
+  - [x] generics types on the invocation
 - [x] anonymous func
   - [x] immediately invoking
 - one line statement

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ func main() {
 			generator.NewRawStatement(`fmt.Println("hello, world!")`),
 		),
 	).
-	Gofmt("-s").
-	Goimports()
+		Gofmt("-s").
+		Goimports()
 
 	generated, err := generator.Generate(0)
 	if err != nil {
@@ -83,18 +83,18 @@ func main() {
 				TypeParameters(TypeParameters{
 					generator.NewTypeParameter("U", "any"),
 				}).
-				ReturnTypeStatements(generator.NewFuncReturnTypeWithTypeParam("MyStruct", []string{"U"})),
+				ReturnTypeStatements(generator.NewFuncReturnTypeWithGenerics("MyStruct", generator.TypeParameterNames{"U"})),
 		).AddStatements(generator.NewComment("do something")),
 		generator.NewNewline(),
 		generator.NewFunc(
-			generator.NewFuncReceiver("s", "MyStruct", "T"),
+			generator.NewFuncReceiverWithGenerics("s", "MyStruct", generator.TypeParameterNames{"T"}),
 			generator.NewFuncSignature("bar").
-				ReturnTypeStatements(generator.NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T"})),
+				ReturnTypeStatements(generator.NewFuncReturnTypeWithGenerics("MyStruct", generator.TypeParameterNames{"T"})),
 		).AddStatements(generator.NewComment("do something")),
 	).
-	Gofmt("-s").
-	Goimports().
-	Generate(0)
+		Gofmt("-s").
+		Goimports().
+		Generate(0)
 
 	if err != nil {
 		panic(err)
@@ -179,6 +179,7 @@ Error messages example:
   - [x] newline
   - [x] `return`
   - [x] `comment`
+- [x] union types in the generics type parameters
 
 For developers of this library
 --

--- a/generator/func_invocation.go
+++ b/generator/func_invocation.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
@@ -11,7 +10,7 @@ import (
 type FuncInvocation struct {
 	parameters    []string
 	callers       []string
-	genericsTypes []string
+	genericsTypes TypeArguments
 }
 
 // NewFuncInvocation returns a new `FuncInvocation`.
@@ -19,7 +18,7 @@ func NewFuncInvocation(parameters ...string) *FuncInvocation {
 	return &FuncInvocation{
 		parameters:    parameters,
 		callers:       fetchClientCallerLineAsSlice(len(parameters)),
-		genericsTypes: []string{},
+		genericsTypes: TypeArguments{},
 	}
 }
 
@@ -44,7 +43,7 @@ func (fig *FuncInvocation) Parameters(parameters ...string) *FuncInvocation {
 }
 
 // GenericsTypes makes a new FuncInvocation value that is based on the receiver value with the given generics type names.
-func (fig *FuncInvocation) GenericsTypes(typeNames ...string) *FuncInvocation {
+func (fig *FuncInvocation) GenericsTypes(typeNames TypeArguments) *FuncInvocation {
 	return &FuncInvocation{
 		parameters:    fig.parameters,
 		callers:       fig.callers,
@@ -62,7 +61,7 @@ func (fig *FuncInvocation) Generate(indentLevel int) (string, error) {
 
 	generics := ""
 	if len(fig.genericsTypes) > 0 {
-		generics = fmt.Sprintf("[%s]", strings.Join(fig.genericsTypes, ", "))
+		generics, _ = fig.genericsTypes.Generate(0)
 	}
 
 	return generics + "(" + strings.Join(fig.parameters, ", ") + ")", nil

--- a/generator/func_invocation_doc_test.go
+++ b/generator/func_invocation_doc_test.go
@@ -16,7 +16,7 @@ func ExampleFuncInvocation_Generate() {
 }
 
 func ExampleFuncInvocation_Generate_withGenericsTypes() {
-	generator := NewFuncInvocation("foo").AddParameters("bar").GenericsTypes("string", "int64")
+	generator := NewFuncInvocation("foo").AddParameters("bar").GenericsTypes(TypeArguments{"string", "int64"})
 
 	generated, err := generator.Generate(0)
 	if err != nil {

--- a/generator/func_invocation_doc_test.go
+++ b/generator/func_invocation_doc_test.go
@@ -14,3 +14,13 @@ func ExampleFuncInvocation_Generate() {
 	}
 	fmt.Println(generated)
 }
+
+func ExampleFuncInvocation_Generate_withGenericsTypes() {
+	generator := NewFuncInvocation("foo").AddParameters("bar").GenericsTypes("string", "int64")
+
+	generated, err := generator.Generate(0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(generated)
+}

--- a/generator/func_invocation_test.go
+++ b/generator/func_invocation_test.go
@@ -32,12 +32,12 @@ func TestShouldGenerateFuncInvocationCode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "(buz)", gen)
 
-	generator = generator.GenericsTypes("string")
+	generator = generator.GenericsTypes(TypeArguments{"string"})
 	gen, err = generator.Generate(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "[string](buz)", gen)
 
-	generator = generator.GenericsTypes("string", "int")
+	generator = generator.GenericsTypes(TypeArguments{"string", "int"})
 	gen, err = generator.Generate(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "[string, int](buz)", gen)

--- a/generator/func_invocation_test.go
+++ b/generator/func_invocation_test.go
@@ -31,6 +31,16 @@ func TestShouldGenerateFuncInvocationCode(t *testing.T) {
 	gen, err = generator.Generate(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "(buz)", gen)
+
+	generator = generator.GenericsTypes("string")
+	gen, err = generator.Generate(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "[string](buz)", gen)
+
+	generator = generator.GenericsTypes("string", "int")
+	gen, err = generator.Generate(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "[string, int](buz)", gen)
 }
 
 func TestShouldGenerateFuncInvocationRaisesErrorWhenParameterIsEmpty(t *testing.T) {

--- a/generator/func_receiver.go
+++ b/generator/func_receiver.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
 )
@@ -12,11 +11,15 @@ type FuncReceiver struct {
 	name                       string
 	typ                        string
 	caller                     string
-	genericsTypeParameterNames []string
+	genericsTypeParameterNames TypeParameterNames
 }
 
 // NewFuncReceiver returns a new `FuncReceiver`.
-func NewFuncReceiver(name string, typ string, genericsTypeParameterNames ...string) *FuncReceiver {
+func NewFuncReceiver(name string, typ string) *FuncReceiver {
+	return NewFuncReceiverWithGenerics(name, typ, TypeParameterNames{})
+}
+
+func NewFuncReceiverWithGenerics(name string, typ string, genericsTypeParameterNames TypeParameterNames) *FuncReceiver {
 	return &FuncReceiver{
 		name:                       name,
 		typ:                        typ,
@@ -44,7 +47,7 @@ func (f *FuncReceiver) Generate(indentLevel int) (string, error) {
 
 	genericsTypeParam := ""
 	if len(f.genericsTypeParameterNames) > 0 {
-		genericsTypeParam = "[" + strings.Join(f.genericsTypeParameterNames, ", ") + "]"
+		genericsTypeParam, _ = f.genericsTypeParameterNames.Generate(0)
 	}
 
 	return fmt.Sprintf("(%s %s%s)", name, typ, genericsTypeParam), nil

--- a/generator/func_receiver.go
+++ b/generator/func_receiver.go
@@ -2,23 +2,26 @@ package generator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/moznion/gowrtr/internal/errmsg"
 )
 
 // FuncReceiver represents a code generator for the receiver of the func.
 type FuncReceiver struct {
-	name   string
-	typ    string
-	caller string
+	name                       string
+	typ                        string
+	caller                     string
+	genericsTypeParameterNames []string
 }
 
 // NewFuncReceiver returns a new `FuncReceiver`.
-func NewFuncReceiver(name string, typ string) *FuncReceiver {
+func NewFuncReceiver(name string, typ string, genericsTypeParameterNames ...string) *FuncReceiver {
 	return &FuncReceiver{
-		name:   name,
-		typ:    typ,
-		caller: fetchClientCallerLine(),
+		name:                       name,
+		typ:                        typ,
+		caller:                     fetchClientCallerLine(),
+		genericsTypeParameterNames: genericsTypeParameterNames,
 	}
 }
 
@@ -39,5 +42,10 @@ func (f *FuncReceiver) Generate(indentLevel int) (string, error) {
 		return "", errmsg.FuncReceiverTypeIsEmptyError(f.caller)
 	}
 
-	return fmt.Sprintf("(%s %s)", name, typ), nil
+	genericsTypeParam := ""
+	if len(f.genericsTypeParameterNames) > 0 {
+		genericsTypeParam = "[" + strings.Join(f.genericsTypeParameterNames, ", ") + "]"
+	}
+
+	return fmt.Sprintf("(%s %s%s)", name, typ, genericsTypeParam), nil
 }

--- a/generator/func_receiver_doc_test.go
+++ b/generator/func_receiver_doc_test.go
@@ -14,3 +14,13 @@ func ExampleFuncReceiver_Generate() {
 	}
 	fmt.Println(generated)
 }
+
+func ExampleFuncReceiver_Generate_withGenericsTypeParameterNames() {
+	funcReceiver := NewFuncReceiver("f", "*Foo", "T", "U")
+
+	generated, err := funcReceiver.Generate(0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(generated)
+}

--- a/generator/func_receiver_doc_test.go
+++ b/generator/func_receiver_doc_test.go
@@ -16,7 +16,7 @@ func ExampleFuncReceiver_Generate() {
 }
 
 func ExampleFuncReceiver_Generate_withGenericsTypeParameterNames() {
-	funcReceiver := NewFuncReceiver("f", "*Foo", "T", "U")
+	funcReceiver := NewFuncReceiverWithGenerics("f", "*Foo", TypeParameterNames{"T", "U"})
 
 	generated, err := funcReceiver.Generate(0)
 	if err != nil {

--- a/generator/func_receiver_test.go
+++ b/generator/func_receiver_test.go
@@ -41,14 +41,14 @@ func TestShouldGeneratingFuncReceiverRaisesErrorWhenFuncReceiverTypeIsEmpty(t *t
 }
 
 func TestShouldGeneratingFuncReceiverCodeWithGenericsTypeParamNameSuccessfully(t *testing.T) {
-	funcReceiver := NewFuncReceiver("f", "*Foo", "T")
+	funcReceiver := NewFuncReceiverWithGenerics("f", "*Foo", TypeParameterNames{"T"})
 	gen, err := funcReceiver.Generate(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "(f *Foo[T])", gen)
 }
 
 func TestShouldGeneratingFuncReceiverCodeWithGenericsTypeParamNamesSuccessfully(t *testing.T) {
-	funcReceiver := NewFuncReceiver("f", "*Foo", "T", "U")
+	funcReceiver := NewFuncReceiverWithGenerics("f", "*Foo", TypeParameterNames{"T", "U"})
 	gen, err := funcReceiver.Generate(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "(f *Foo[T, U])", gen)

--- a/generator/func_receiver_test.go
+++ b/generator/func_receiver_test.go
@@ -39,3 +39,17 @@ func TestShouldGeneratingFuncReceiverRaisesErrorWhenFuncReceiverTypeIsEmpty(t *t
 		`^\`+strings.Split(errmsg.FuncReceiverTypeIsEmptyError("").Error(), " ")[0],
 	), err.Error())
 }
+
+func TestShouldGeneratingFuncReceiverCodeWithGenericsTypeParamNameSuccessfully(t *testing.T) {
+	funcReceiver := NewFuncReceiver("f", "*Foo", "T")
+	gen, err := funcReceiver.Generate(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "(f *Foo[T])", gen)
+}
+
+func TestShouldGeneratingFuncReceiverCodeWithGenericsTypeParamNamesSuccessfully(t *testing.T) {
+	funcReceiver := NewFuncReceiver("f", "*Foo", "T", "U")
+	gen, err := funcReceiver.Generate(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "(f *Foo[T, U])", gen)
+}

--- a/generator/func_signature.go
+++ b/generator/func_signature.go
@@ -17,7 +17,7 @@ type FuncParameter struct {
 type FuncReturnType struct {
 	name                       string
 	typ                        string
-	genericsTypeParameterNames []string
+	genericsTypeParameterNames TypeParameterNames
 }
 
 // Generate generates a return type of the func as golang code.
@@ -32,7 +32,8 @@ func (frt *FuncReturnType) Generate(indentLevel int) (string, error) {
 	stmt += typ
 
 	if len(frt.genericsTypeParameterNames) > 0 {
-		stmt += "[" + strings.Join(frt.genericsTypeParameterNames, ", ") + "]"
+		paramNamesStmt, _ := frt.genericsTypeParameterNames.Generate(0)
+		stmt += paramNamesStmt
 	}
 
 	return stmt, nil
@@ -60,11 +61,11 @@ func NewFuncParameter(name string, typ string) *FuncParameter {
 // NewFuncReturnType returns a new `FuncReturnType`.
 // `name` is an optional parameter. If this parameter is specified, FuncReturnType generates code as named return type.
 func NewFuncReturnType(typ string, name ...string) *FuncReturnType {
-	return NewFuncReturnTypeWithTypeParam(typ, []string{}, name...)
+	return NewFuncReturnTypeWithGenerics(typ, []string{}, name...)
 }
 
-// NewFuncReturnTypeWithTypeParam ret	urns a new `FuncReturnType` with the generics type parameter name, e.g. `T`.
-func NewFuncReturnTypeWithTypeParam(typ string, genericsTypeParameterNames []string, name ...string) *FuncReturnType {
+// NewFuncReturnTypeWithGenerics ret	urns a new `FuncReturnType` with the generics type parameter name, e.g. `T`.
+func NewFuncReturnTypeWithGenerics(typ string, genericsTypeParameterNames TypeParameterNames, name ...string) *FuncReturnType {
 	n := ""
 	if len(name) > 0 {
 		n = name[0]

--- a/generator/func_signature_doc_test.go
+++ b/generator/func_signature_doc_test.go
@@ -13,7 +13,10 @@ func ExampleFuncSignature_Generate() {
 	}).AddParameters(
 		NewFuncParameter("foo", "T"),
 		NewFuncParameter("bar", "int"),
-	).AddReturnTypes("T", "error")
+	).AddReturnTypeStatements(
+		NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T", "U"}),
+		NewFuncReturnType("error"),
+	)
 
 	generated, err := generator.Generate(0)
 	if err != nil {

--- a/generator/func_signature_doc_test.go
+++ b/generator/func_signature_doc_test.go
@@ -14,7 +14,7 @@ func ExampleFuncSignature_Generate() {
 		NewFuncParameter("foo", "T"),
 		NewFuncParameter("bar", "int"),
 	).AddReturnTypeStatements(
-		NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T", "U"}),
+		NewFuncReturnTypeWithGenerics("MyStruct", TypeParameterNames{"T", "U"}),
 		NewFuncReturnType("error"),
 	)
 

--- a/generator/func_signature_test.go
+++ b/generator/func_signature_test.go
@@ -101,7 +101,7 @@ func TestShouldGeneratingFuncSignatureBeSuccessful(t *testing.T) {
 			NewFuncParameter("foo", "T"),
 			NewFuncParameter("bar", "U"),
 		).AddReturnTypeStatements(
-			NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T"}),
+			NewFuncReturnTypeWithGenerics("MyStruct", TypeParameterNames{"T"}),
 			NewFuncReturnType("error"),
 		),
 
@@ -114,7 +114,7 @@ func TestShouldGeneratingFuncSignatureBeSuccessful(t *testing.T) {
 			NewFuncParameter("foo", "T"),
 			NewFuncParameter("bar", "U"),
 		).AddReturnTypeStatements(
-			NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T", "U"}),
+			NewFuncReturnTypeWithGenerics("MyStruct", TypeParameterNames{"T", "U"}),
 			NewFuncReturnType("error"),
 		),
 	}

--- a/generator/func_signature_test.go
+++ b/generator/func_signature_test.go
@@ -81,6 +81,42 @@ func TestShouldGeneratingFuncSignatureBeSuccessful(t *testing.T) {
 			NewFuncParameter("foo", "T"),
 			NewFuncParameter("bar", "int"),
 		).AddReturnTypes("T", "error"),
+
+		"myFunc[T string, U int64](\n\tfoo T,\n\tbar U,\n) (T, error)": NewFuncSignature(
+			"myFunc",
+		).TypeParameters(TypeParameters{
+			NewTypeParameter("T", "string"),
+			NewTypeParameter("U", "int64"),
+		}).AddParameters(
+			NewFuncParameter("foo", "T"),
+			NewFuncParameter("bar", "U"),
+		).AddReturnTypes("T", "error"),
+
+		"myFunc[T string, U int64](\n\tfoo T,\n\tbar U,\n) (MyStruct[T], error)": NewFuncSignature(
+			"myFunc",
+		).TypeParameters(TypeParameters{
+			NewTypeParameter("T", "string"),
+			NewTypeParameter("U", "int64"),
+		}).AddParameters(
+			NewFuncParameter("foo", "T"),
+			NewFuncParameter("bar", "U"),
+		).AddReturnTypeStatements(
+			NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T"}),
+			NewFuncReturnType("error"),
+		),
+
+		"myFunc[T string, U int64](\n\tfoo T,\n\tbar U,\n) (MyStruct[T, U], error)": NewFuncSignature(
+			"myFunc",
+		).TypeParameters(TypeParameters{
+			NewTypeParameter("T", "string"),
+			NewTypeParameter("U", "int64"),
+		}).AddParameters(
+			NewFuncParameter("foo", "T"),
+			NewFuncParameter("bar", "U"),
+		).AddReturnTypeStatements(
+			NewFuncReturnTypeWithTypeParam("MyStruct", []string{"T", "U"}),
+			NewFuncReturnType("error"),
+		),
 	}
 
 	for expected, signature := range dataset {

--- a/generator/interface.go
+++ b/generator/interface.go
@@ -11,6 +11,7 @@ type Interface struct {
 	name           string
 	funcSignatures []*FuncSignature
 	caller         string
+	typeParameters TypeParameters
 }
 
 // NewInterface returns a new `Interface`.
@@ -42,6 +43,16 @@ func (ig *Interface) Signatures(sig ...*FuncSignature) *Interface {
 	}
 }
 
+// TypeParameters makes a new Interface value based on the receiver value with the given generics TypeParameters.
+func (ig *Interface) TypeParameters(typeParameters TypeParameters) *Interface {
+	return &Interface{
+		name:           ig.name,
+		funcSignatures: ig.funcSignatures,
+		caller:         ig.caller,
+		typeParameters: typeParameters,
+	}
+}
+
 // Generate generates `interface` block as golang code.
 func (ig *Interface) Generate(indentLevel int) (string, error) {
 	if ig.name == "" {
@@ -50,8 +61,17 @@ func (ig *Interface) Generate(indentLevel int) (string, error) {
 
 	indent := BuildIndent(indentLevel)
 
+	typeParamStmt := ""
+	if len(ig.typeParameters) > 0 {
+		var err error
+		typeParamStmt, err = ig.typeParameters.Generate(0)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	nextIndentLevel := indentLevel + 1
-	stmt := fmt.Sprintf("%stype %s interface {\n", indent, ig.name)
+	stmt := fmt.Sprintf("%stype %s%s interface {\n", indent, ig.name, typeParamStmt)
 	for _, sig := range ig.funcSignatures {
 		signatureStr, err := sig.Generate(nextIndentLevel)
 		if err != nil {

--- a/generator/interface_doc_test.go
+++ b/generator/interface_doc_test.go
@@ -9,11 +9,13 @@ func ExampleInterface_Generate() {
 	generator := NewInterface(
 		"MyInterface",
 		NewFuncSignature("fooFunc").
-			AddParameters(NewFuncParameter("foo", "string")).
+			AddParameters(NewFuncParameter("foo", "T")).
 			AddReturnTypes("string", "error"),
 	).AddSignatures(
 		NewFuncSignature("barFunc"),
-	)
+	).TypeParameters(TypeParameters{
+		NewTypeParameter("T", "any"),
+	})
 
 	generated, err := generator.Generate(0)
 	if err != nil {

--- a/generator/struct_test.go
+++ b/generator/struct_test.go
@@ -41,7 +41,7 @@ func TestShouldGenerateStructStatementBeSucceeded(t *testing.T) {
 	}
 }
 
-func TestShouldGenerateStructStatementWithTypeParametersSuccessfully(t *testing.T) {
+func TestShouldGenerateStructStatementWithTypeParameterSuccessfully(t *testing.T) {
 	generator := NewStruct("TestStruct")
 	generator = generator.
 		TypeParameters(TypeParameters{NewTypeParameter("T", "string")}).
@@ -52,6 +52,25 @@ func TestShouldGenerateStructStatementWithTypeParametersSuccessfully(t *testing.
 	expected := "type TestStruct[T string] struct {\n" +
 		"	Foo T\n" +
 		"	Bar int64 `json:\"bar\"`\n" +
+		"}\n"
+	assert.NoError(t, err)
+	assert.Equal(t, expected, gen)
+}
+
+func TestShouldGenerateStructStatementWithTypeParametersSuccessfully(t *testing.T) {
+	generator := NewStruct("TestStruct")
+	generator = generator.
+		TypeParameters(TypeParameters{
+			NewTypeParameter("T", "string"),
+			NewTypeParameter("U", "int64"),
+		}).
+		AddField("Foo", "T").
+		AddField("Bar", "U", `json:"bar"`)
+
+	gen, err := generator.Generate(0)
+	expected := "type TestStruct[T string, U int64] struct {\n" +
+		"	Foo T\n" +
+		"	Bar U `json:\"bar\"`\n" +
 		"}\n"
 	assert.NoError(t, err)
 	assert.Equal(t, expected, gen)

--- a/generator/type_parameters.go
+++ b/generator/type_parameters.go
@@ -66,3 +66,11 @@ type TypeArguments []string
 func (tas TypeArguments) Generate(indentLevel int) (string, error) {
 	return "[" + strings.Join(tas, ", ") + "]", nil
 }
+
+// TypeParameterNames is an array of type parameter names (e.g. `T`) for go generics.
+type TypeParameterNames []string
+
+// Generate generates the type parameter names as golang code.
+func (tpn TypeParameterNames) Generate(indentLevel int) (string, error) {
+	return "[" + strings.Join(tpn, ", ") + "]", nil
+}

--- a/generator/type_parameters_test.go
+++ b/generator/type_parameters_test.go
@@ -24,8 +24,20 @@ func TestShouldFailToGenerateTypeParametersWhenParameterIsEmpty(t *testing.T) {
 	assert.Equal(t, errmsg.TypeParameterParameterIsEmptyErrType, errmsg.IdentifyErrs(err))
 }
 
+func TestShouldGenerateUnionTypeParameterSuccessfully(t *testing.T) {
+	stmt, err := TypeParameters{NewTypeParameters("T", []string{"int", "uint"})}.Generate(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "[T int | uint]", stmt)
+}
+
 func TestShouldFailToGenerateTypeParametersWhenTypeIsEmpty(t *testing.T) {
 	_, err := TypeParameters{NewTypeParameter("T", "")}.Generate(0)
+	assert.Error(t, err)
+	assert.Equal(t, errmsg.TypeParameterTypeIsEmptyErrType, errmsg.IdentifyErrs(err))
+}
+
+func TestShouldGenerateUnionTypeParametersWhenTypesSliceIsEmpty(t *testing.T) {
+	_, err := TypeParameters{NewTypeParameters("T", []string{})}.Generate(0)
 	assert.Error(t, err)
 	assert.Equal(t, errmsg.TypeParameterTypeIsEmptyErrType, errmsg.IdentifyErrs(err))
 }


### PR DESCRIPTION
Support the generics syntax in the following syntaxes/notations:

- generic types on function invocation like `foo[int64](123)`
- generic parameter names on function receiver like `func (s MyStruct[T])`
- generic parameter names on function return values like `func foo[T struct]() MyStruct[T]`
- generic type parameters on interface declaration like `type MyInterface[T any] interface {}`

And this patch also introduces `TypeParameterNames` which is an alias of `[]string` to represent the generic parameter names, e.g. `T`.